### PR TITLE
Remove dead link to alternative project

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,6 @@
 You can use instead https://github.com/gilesknap/gphotos-sync which is a fork from
 this project with considerable changes to address a lot of its shortcomings.
 
-*(Also monitor closely https://github.com/gilesknap/gphotos-sync2 which will use the
-recent official Google Photo API and should be a more sustainable solution).*
-
 
 ====================
  Google Photos Sync


### PR DESCRIPTION
There is only a `gilesknap/gphotos-sync` and no `gilesknap/gphotos-sync2`